### PR TITLE
docs: Rewrite README.md for clarity and detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,995 +1,416 @@
-# twat-cache
+# twat-cache: Flexible Caching for Python
 
-A flexible caching utility package for Python functions that provides a unified interface for caching function results using various high-performance backends.
+**Part of the [twat](https://pypi.org/project/twat/) collection of Python utilities.**
 
-## Features
+`twat-cache` is a versatile and high-performance Python library designed to simplify caching for your functions. It provides a unified and easy-to-use interface to various caching backends, allowing you to speed up your applications by storing and retrieving the results of expensive computations without significant code changes.
 
-- Simple decorator interface for caching function results
-- Multiple caching backends with automatic selection:
-  1. `cachebox` - Very fast Rust-based cache (optional)
-  2. `cachetools` - Flexible in-memory caching (optional)
-  3. `aiocache` - Async-capable caching (optional)
-  4. `klepto` - Scientific computing caching (optional)
-  5. `diskcache` - SQL-based disk cache (optional)
-  6. `joblib` - Efficient array caching (optional)
-  7. `redis` - Distributed caching with Redis (optional)
-  8. Memory-based LRU cache (always available)
-- Automatic cache directory management
-- Type hints and modern Python features
-- Lazy backend loading - only imports what you use
-- Automatic backend selection based on availability and use case
-- Smart backend selection based on data characteristics
-- TTL support for cache expiration
-- Multiple eviction policies (LRU, LFU, FIFO, RR)
-- Async function support
-- Compression options for large data
-- Secure file permissions for sensitive data
-- Hybrid caching with automatic backend switching
-- Context management for cache engines
-- Comprehensive test suite for all components
+## What is `twat-cache`?
 
-## Recent Updates (v2.3.0)
+At its core, `twat-cache` offers a set of decorators that you can apply to your Python functions. When a decorated function is called, `twat-cache` checks if the result for the given arguments already exists in its cache. If so, it returns the cached result immediately, bypassing the actual function execution. If not, the function executes, and its result is stored in the cache for future calls.
 
-### Enhanced Context Management
+This mechanism can drastically reduce execution time for functions that are called repeatedly with the same inputs, especially if those functions perform I/O operations (like web requests or database queries) or complex calculations.
 
-The context management system has been significantly improved:
-- Better error handling and resource cleanup
-- Support for explicit engine selection
-- Simplified API for temporary cache configurations
-- Automatic cleanup of resources even when exceptions occur
+## Who is it for?
 
-```python
-# Example of improved context management
-from twat_cache import CacheContext
+`twat-cache` is for Python developers who want to:
 
-# Create a context with explicit engine selection
-with CacheContext(engine_name="redis", namespace="user_data") as cache:
-    # Use the cache within the context
-    cache.set("user:1001", {"name": "John", "role": "admin"})
-    user = cache.get("user:1001")
-    
-    # Resources are automatically cleaned up when exiting the context
-```
+*   Improve the performance and responsiveness of their applications.
+*   Reduce redundant computations or data fetching.
+*   Simplify the implementation of caching logic.
+*   Have the flexibility to choose from different caching strategies (in-memory, disk-based, file-based) without rewriting their code.
+*   Work with both synchronous and asynchronous Python code.
 
-### Refined Backend Selection
+Whether you're building web applications, data processing pipelines, scientific computing tools, or any Python project where performance matters, `twat-cache` can be a valuable addition.
 
-The backend selection strategy has been further enhanced:
-- More accurate data type detection for optimal backend selection
-- Improved fallback mechanisms when preferred backends are unavailable
-- Better handling of edge cases for various data types
-- Enhanced performance for frequently accessed items
+## Why is it useful?
 
-### Comprehensive Documentation
-
-Documentation has been expanded with:
-- Detailed examples for all cache backends
-- Step-by-step guides for common use cases
-- API reference with complete parameter descriptions
-- Best practices for cache configuration
+*   **Unified Interface:** Learn one way to cache, and apply it across multiple cache engines.
+*   **Automatic Engine Selection:** The `ucache` (universal cache) decorator can intelligently pick a suitable cache engine, or you can explicitly choose one.
+*   **Multiple Cache Engines & Backends:** Supports several caching strategies by integrating with robust backend libraries:
+    *   In-memory (LRU, LFU, FIFO policies via `cachetools` library, or high-performance `cachebox` library)
+    *   Disk-based (persistent caching via `diskcache` library)
+    *   File-based (efficient for large objects like NumPy arrays via `joblib` library)
+    *   Asynchronous caching (for `async/await` functions via `aiocache` library)
+*   **Fallback Mechanism:** If a preferred cache engine or its underlying backend library isn't available, `twat-cache` gracefully falls back to a functional alternative.
+*   **Configurable:** Control cache size (`maxsize`), time-to-live (`ttl`) for entries, eviction policies, and more.
+*   **Context Management:** Provides `CacheContext` for fine-grained control over cache engine lifecycles and configurations within specific code blocks.
+*   **Modern Python:** Built with type hints and supports modern Python features.
+*   **Part of a Larger Ecosystem:** As a component of the `twat` project, it aims for consistency and quality within that suite of tools.
 
 ## Installation
 
-Basic installation with just LRU caching:
+You can install `twat-cache` using pip.
+
+**Basic Installation (includes in-memory and basic disk caching capabilities):**
+
 ```bash
 pip install twat-cache
 ```
 
-With all optional backends:
+This installs `twat-cache` along with `pydantic`, `loguru`, `diskcache`, `joblib`, and `cachetools`.
+
+**To include all optional backend libraries for extended capabilities:**
+
 ```bash
 pip install twat-cache[all]
 ```
+This adds support for `cachebox`, `aiocache`, `klepto`, and `platformdirs`.
 
-Or install specific backends:
-```bash
-pip install twat-cache[cachebox]     # For Rust-based high-performance cache
-pip install twat-cache[cachetools]   # For flexible in-memory caching
-pip install twat-cache[aiocache]     # For async-capable caching
-pip install twat-cache[klepto]       # For scientific computing caching
-pip install twat-cache[diskcache]    # For SQL-based disk caching
-pip install twat-cache[joblib]       # For efficient array caching
-pip install twat-cache[redis]        # For distributed caching with Redis
-```
+**To install support for specific optional backend libraries:**
 
-## Usage
+Choose the backend libraries that enable the cache engines you need:
 
-### Basic Memory Caching
+*   **cachebox (High-performance Rust-based in-memory cache):**
+    ```bash
+    pip install twat-cache[cachebox]
+    ```
+*   **aiocache (Async-capable caching):**
+    ```bash
+    pip install twat-cache[aiocache]
+    ```
+*   **klepto (Scientific computing caching, various storage options):**
+    ```bash
+    pip install twat-cache[klepto]
+    ```
 
-For simple in-memory caching with LRU eviction:
+*Note on Redis:* Previous versions or documentation might have mentioned a Redis cache engine. Currently, the direct implementation for a Redis engine (`redis.py`) is not present in the core `twat_cache.engines` directory. While `pyproject.toml` might list a `redis` extra, ensure the `redis-py` (or equivalent) package is installed and that `twat-cache` explicitly supports it in the version you are using if Redis is a requirement. The `CacheEngineManager` has a provision to load a Redis engine, but the engine code itself must be available.
+
+## How to Use `twat-cache`
+
+`twat-cache` is primarily used as a library by importing its decorators and context managers into your Python code. It does not currently offer a standalone command-line interface for direct cache manipulation outside of a Python script.
+
+### Programmatic Usage (Examples)
+
+Here are some common ways to use `twat-cache`:
+
+**1. In-Memory Caching (`mcache`)**
+
+Ideal for fast, temporary caching of frequently accessed, small-to-medium sized data within a single process.
 
 ```python
 from twat_cache import mcache
+import time
 
-@mcache(maxsize=100)  # Cache up to 100 items
-def expensive_function(x: int) -> int:
-    # Expensive computation here
-    return x * x
+@mcache(maxsize=128, ttl=60) # Cache up to 128 items, expire after 60 seconds
+def get_user_details(user_id: int) -> dict:
+    print(f"Fetching details for user {user_id}...")
+    time.sleep(1) # Simulate expensive operation
+    return {"id": user_id, "name": f"User {user_id}", "email": f"user{user_id}@example.com"}
 
-# First call computes
-result1 = expensive_function(5)  # Computes 25
+# First call: fetches and caches
+user1 = get_user_details(1)
+print(user1)
 
-# Second call uses cache
-result2 = expensive_function(5)  # Returns cached 25
+# Second call: result comes from cache
+user1_cached = get_user_details(1)
+print(user1_cached)
+
+# After 60 seconds, or if maxsize is exceeded, the cache entry might be evicted.
 ```
 
-### Disk-Based Caching
+**2. Disk-Based Caching (`bcache`)**
 
-For persistent caching using SQLite:
+Useful for persistent caching across application restarts or for larger datasets that don't fit comfortably in memory. Uses the `diskcache` library.
 
 ```python
 from twat_cache import bcache
+import time
 
-@bcache(
-    folder_name="my_cache",  # Cache directory name
-    maxsize=1_000_000,       # Max cache size in bytes
-    ttl=3600,               # Cache entries expire after 1 hour
-    use_sql=True,           # Use SQLite backend
-    secure=True,            # Use secure file permissions
-)
-def expensive_function(x: int) -> int:
-    return x * x
+@bcache(folder_name="user_data_cache", ttl=3600) # Cache in '.cache/twat_cache/user_data_cache', expire after 1 hour
+def get_report_data(report_id: str) -> list:
+    print(f"Generating report {report_id}...")
+    time.sleep(2) # Simulate expensive report generation
+    return [{"report": report_id, "data_point": i} for i in range(5)]
+
+# First call: generates and caches to disk
+report_A = get_report_data("A")
+print(report_A)
+
+# Second call (even after script restart): result comes from disk cache
+report_A_cached = get_report_data("A")
+print(report_A_cached)
 ```
 
-### Redis Distributed Caching
+**3. File-Based Caching for Large Objects (`fcache`)**
 
-For distributed caching with Redis:
-
-```python
-from twat_cache import ucache
-
-@ucache(
-    preferred_engine="redis",
-    folder_name="redis_cache",  # Used as Redis namespace
-    ttl=3600,                  # Cache entries expire after 1 hour
-    compress=True,             # Enable compression
-)
-def expensive_function(x: int) -> int:
-    return x * x
-```
-
-### File-Based Caching
-
-For efficient caching of large objects like NumPy arrays:
+Optimized for caching large objects like NumPy arrays or machine learning models, typically using the `joblib` library.
 
 ```python
 from twat_cache import fcache
 import numpy as np
+import time
 
-@fcache(
-    folder_name="array_cache",
-    compress=True,           # Enable compression
-    secure=True,            # Use secure file permissions
-)
-def process_array(data: np.ndarray) -> np.ndarray:
-    # Expensive array processing here
-    return data * 2
+@fcache(folder_name="array_processing_cache", compress=True) # Compress cached files
+def process_large_array(size: int) -> np.ndarray:
+    print(f"Processing large array of size {size}x{size}...")
+    time.sleep(3) # Simulate heavy computation
+    return np.random.rand(size, size)
+
+# First call: computes and caches the array to a file
+array_data = process_large_array(1000)
+print(array_data.shape)
+
+# Second call: loads the array from the cached file
+array_data_cached = process_large_array(1000)
+print(array_data_cached.shape)
 ```
 
-### Async Caching
+**4. Asynchronous Caching (`acache`)**
 
-For async functions with Redis or memory backend:
+For caching results of `async` functions, typically using the `aiocache` library.
+
+```python
+from twat_cache import acache
+import asyncio
+import time
+
+@acache(ttl=300) # Cache async results for 5 minutes
+async def fetch_external_data(url: str) -> dict:
+    print(f"Fetching data from {url}...")
+    await asyncio.sleep(1) # Simulate async HTTP request
+    return {"url": url, "content": f"Data from {url}"}
+
+async def main():
+    # First call: fetches and caches
+    data1 = await fetch_external_data("https://api.example.com/data")
+    print(data1)
+
+    # Second call: result comes from cache
+    data1_cached = await fetch_external_data("https://api.example.com/data")
+    print(data1_cached)
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+**5. Universal Caching (`ucache`)**
+
+Let `twat-cache` attempt to pick the best cache engine based on availability and function characteristics.
 
 ```python
 from twat_cache import ucache
+import time
 
-@ucache(use_async=True)
-async def fetch_data(url: str) -> dict:
-    # Async web request here
-    return {"data": "..."}
+@ucache(ttl=1800, compress=True) # Universal cache, expire after 30 mins, try compression
+def complex_calculation(a: int, b: float, c: str) -> str:
+    print(f"Performing complex calculation with {a}, {b}, {c}...")
+    time.sleep(1.5)
+    return f"Result: {a * b} - {c.upper()}"
 
-# First call fetches
-data1 = await fetch_data("https://api.example.com")
+# twat-cache will choose an appropriate engine (e.g., DiskCacheEngine if available and suitable)
+res1 = complex_calculation(10, 2.5, "hello")
+print(res1)
 
-# Second call uses cache
-data2 = await fetch_data("https://api.example.com")
+res1_cached = complex_calculation(10, 2.5, "hello")
+print(res1_cached)
 ```
 
-### Universal Caching
+**6. Using Cache Context (`CacheContext`)**
 
-Let the library choose the best backend:
+For more explicit control over caching within a specific block of code, or for using cache engines directly.
 
 ```python
-from twat_cache import ucache
+from twat_cache import CacheContext
+import time # Ensure time is imported for the example
 
-@ucache(
-    folder_name="cache",     # Optional - uses disk cache if provided
-    maxsize=1000,           # Optional - limits cache size
-    ttl=3600,              # Optional - entries expire after 1 hour
-    policy="lru",          # Optional - LRU eviction (default)
-    use_sql=True,          # Optional - use SQL backend if available
-    compress=True,         # Optional - enable compression
-    secure=True,           # Optional - secure file permissions
-)
-def my_function(x: int) -> int:
-    return x * x
+def process_user_session(user_id: str, data: dict):
+    # Use a specific disk cache for this operation
+    with CacheContext(engine_name="diskcache", folder_name="session_cache", ttl=600) as cache:
+        # 'cache' is the cache engine instance, allowing direct get/set.
+        # For DiskCacheEngine, this would be a diskcache.Cache object.
+        cache_key = f"session_data_{user_id}"
+
+        cached_data = cache.get(cache_key)
+        if cached_data:
+            print(f"Using cached session data for {user_id}")
+            return cached_data
+
+        print(f"Processing and caching session data for {user_id}")
+        # Simulate processing
+        processed_data = {**data, "processed_at": time.time()}
+        cache.set(cache_key, processed_data)
+        return processed_data
+
+user_data = {"preferences": "dark_mode"}
+session_info = process_user_session("user123", user_data)
+print(session_info)
+
+session_info_cached = process_user_session("user123", user_data) # Should hit cache
+print(session_info_cached)
 ```
 
-### Smart Backend Selection
+## Technical Details
 
-Automatically select the best backend based on data characteristics:
+This section delves into the internal workings of `twat-cache`, its architecture, and guidelines for coding and contributing.
 
-```python
-from twat_cache import smart_cache
+### How `twat-cache` Works
 
-@smart_cache()
-def process_data(data_type: str, size: int) -> Any:
-    """Process different types of data with automatic backend selection."""
-    if data_type == "dict":
-        return {f"key_{i}": f"value_{i}" for i in range(size)}
-    elif data_type == "list":
-        return [i for i in range(size)]
-    elif data_type == "str":
-        return "x" * size
-    else:
-        return size
+`twat-cache` is structured around a few key components: decorators, configuration objects, cache engines, and management utilities.
+
+**1. Core Decorators (`src/twat_cache/decorators.py`)**
+
+The primary interface for users. These decorators wrap user functions to inject caching logic.
+
+*   **`@mcache` (Memory Cache):**
+    *   Prioritizes fast in-memory cache engines.
+    *   Order of preference: `CacheBoxEngine` (if `cachebox` library is available), then `CacheToolsEngine` (if `cachetools` is available), finally falls back to Python's built-in `functools.lru_cache` (via `FunctoolsEngine`).
+    *   Configuration: `maxsize`, `ttl`, `policy` (LRU, LFU, FIFO, etc.), `secure` (key generation).
+*   **`@bcache` (Basic Disk Cache):**
+    *   Primarily uses `DiskCacheEngine` (which leverages the `diskcache` library) for persistent, SQLite-backed disk storage.
+    *   If `diskcache` is unavailable but `klepto` is (and `use_sql=True` was passed, though this option is being de-emphasized), it can use `KleptoEngine` for SQL-based storage.
+    *   Falls back to `@mcache` if no suitable disk-caching engine is found.
+    *   Configuration: `folder_name`, `maxsize` (bytes on disk), `ttl`, `policy`, `use_sql` (for Klepto), `secure`.
+*   **`@fcache` (File Cache):**
+    *   Designed for large objects, often using serialization strategies suited for items like NumPy arrays.
+    *   Prefers `JoblibEngine` (using `joblib.Memory`) for efficient file-based caching.
+    *   Can fall back to `KleptoEngine` if `joblib` is not available.
+    *   If neither is available, it falls back to `@mcache`.
+    *   Configuration: `folder_name`, `maxsize`, `ttl`, `compress`, `secure`.
+*   **`@acache` (Asynchronous Cache):**
+    *   Specifically for `async def` functions.
+    *   Uses `AioCacheEngine` (leveraging the `aiocache` library) if available.
+    *   If `aiocache` is not available, it uses a synchronous memory cache (`mcache`) to wrap the async function. The caching mechanism then stores the result *after* the initial await, so subsequent calls with the same arguments will return the cached result without re-executing the async operation.
+    *   Configuration: `maxsize`, `ttl`, `policy`.
+*   **`@ucache` (Universal Cache):**
+    *   The most flexible decorator. It attempts to select the "best" available cache engine.
+    *   Selection logic (`_select_best_backend`): Considers if the function is async (prefers `AioCacheEngine`), if disk persistence seems beneficial (e.g., if `folder_name` is provided, hinting at `DiskCacheEngine`, `JoblibEngine`, or `KleptoEngine`), or defaults to fast in-memory options (`CacheBoxEngine`, `CacheToolsEngine`).
+    *   Takes a wide range of configuration options applicable to various engines.
+    *   The actual engine is instantiated via `_create_engine` based on the resolved configuration and selected backend name.
+
+**2. Configuration (`src/twat_cache/config.py`)**
+
+*   **`CacheConfig` (Pydantic Model):** A Pydantic model defines the structure for all cache configurations. This ensures type safety and validation for parameters like `maxsize`, `ttl`, `policy`, `folder_name`, `compress`, `secure`, and `preferred_engine`.
+*   **`create_cache_config(...)`:** A factory function to easily construct `CacheConfig` objects.
+*   Environment variables are not directly used for configuration by default, but `CacheConfig` could be extended or instantiated with values from environment variables programmatically if needed.
+*   Redis-specific configurations were previously part of `CacheConfig` but have been removed, indicating a potential shift or pending refactor for Redis support.
+
+**3. Cache Engines (`src/twat_cache/engines/`)**
+
+This directory contains the actual caching logic implementations, abstracted via a common interface.
+
+*   **`BaseCacheEngine` (Protocol):** Defines the contract for all cache engines. It's expected to have an `__init__(self, config: CacheConfig)` method and a `cache(self, func)` method that returns a wrapped, cached version of the input function. It also has an `is_available()` class method to check if the engine's dependencies (the underlying backend library) are met.
+*   **Engine Implementations:**
+    *   **`FunctoolsEngine`:** Wraps Python's `functools.lru_cache` or `functools.cache`. Always available.
+    *   **`CacheBoxEngine`:** Uses the `cachebox` library for high-performance in-memory caching.
+    *   **`CacheToolsEngine`:** Uses the `cachetools` library for various in-memory eviction policies (LRU, LFU, TTL, FIFO, RR).
+    *   **`DiskCacheEngine`:** Uses the `diskcache` library for persistent, transactional, disk-backed caching (typically SQLite + file system).
+    *   **`JoblibEngine`:** Uses `joblib.Memory` for file-system based caching, particularly efficient for Python objects like NumPy arrays.
+    *   **`KleptoEngine`:** Uses the `klepto` library, which offers a wide range of serialization and storage backends (including file, SQL, HDF5). Its usage in `twat-cache` seems to be de-emphasized in recent changes.
+    *   **`AioCacheEngine`:** Uses the `aiocache` library for caching results of asynchronous functions.
+    *   **`RedisCacheEngine`:** (Potentially) An engine for Redis. As noted, `redis.py` is currently missing from the source tree, so this engine is not practically available unless provided externally or by a specific package version.
+*   **`CacheEngineManager` (`src/twat_cache/engines/manager.py`):**
+    *   Responsible for registering and discovering available cache engine classes.
+    *   `_register_builtin_engines()`: Registers all standard engine types known to `twat-cache`.
+    *   `select_engine()`: Provides logic to pick an engine based on availability and optional preferences. This is used by context managers. Decorators have their own specific fallback chains.
+
+**4. Cache Management (`src/twat_cache/cache.py`)**
+
+*   **Global Cache Registry (`_active_caches`):** A dictionary that keeps track of active cache instances created by the decorators. This allows for global operations.
+*   **`register_cache(name, cache_engine_instance, wrapper, stats)`:** Adds a newly created cache instance to the global registry.
+*   **`clear_cache(name=None)`:** Clears a specific cache by name or all registered caches if no name is provided. It also attempts to clean up associated disk directories.
+*   **`get_stats(name=None)`:** Retrieves statistics (hits, misses, size, maxsize) for a specific cache or aggregated stats for all caches.
+*   **`update_stats(...)`:** Internal helper to update hit/miss counts for a cache.
+
+**5. Context Management (`src/twat_cache/context.py`)**
+
+*   **`CacheContext`:** A class-based context manager.
+    *   Allows for explicit selection of a cache engine (`engine_name`) and configuration for a specific block of code.
+    *   Example: `with CacheContext(engine_name="diskcache", folder_name="my_temp_cache") as cache_instance:`
+    *   The `cache_instance` provided by `as` is intended to be the underlying cache object from the chosen backend library (e.g., a `diskcache.Cache` object) if the `twat-cache` engine wrapper exposes it directly (often via a `_cache` attribute or `cache_instance` property). If not, it will be the `twat-cache` engine wrapper instance itself, which should still provide basic cache operations like `get`, `set`, `delete`.
+    *   Ensures resources (like database connections for `DiskCacheEngine`) are properly initialized and closed.
+*   **`engine_context`:** A function-based context manager, similar in purpose to `CacheContext`, providing a more concise way to achieve the same.
+
+**6. Backend Selection Logic (`_select_best_backend` in `decorators.py`)**
+
+This internal function is used by `@ucache` and potentially by context managers if no engine is explicitly specified.
+
+*   Checks availability of backend libraries (`_get_available_backends`).
+*   Considers `preferred_engine` from config.
+*   Factors in `is_async` (favors `AioCacheEngine`).
+*   Factors in `needs_disk` (favors `DiskCacheEngine`, `KleptoEngine`, `JoblibEngine`).
+*   Has a fallback order if specific requirements aren't met (e.g., `CacheBoxEngine` -> `CacheToolsEngine` -> `FunctoolsEngine` for general in-memory needs).
+
+**7. Key Generation (`make_key` in `decorators.py`)**
+
+*   Responsible for creating a consistent, hashable cache key from the function's arguments (`*args`, `**kwargs`).
+*   Serializes arguments to JSON by default to handle various data types and ensure order doesn't affect the key for keyword arguments.
+*   A custom `serializer` can be provided in `CacheConfig` for handling non-JSON-serializable objects or for custom keying strategies. The `secure=True` option (default) likely implies a more robust serialization.
+
+### Coding and Contributing
+
+**Coding Conventions & Style:**
+
+*   **Python Version:** Requires Python 3.10 or newer (as per `pyproject.toml`).
+*   **Formatting:** Code is formatted using `Black` and `Ruff`. Adherence to these formatters is expected.
+    *   Run `ruff format .` and `ruff check --fix .`
+*   **Linting:** `Ruff` is used for extensive linting, covering rules from Flake8, isort, pep8-naming, and more.
+    *   Run `ruff check .`
+*   **Type Checking:** Static type checking is enforced using `MyPy`. All new code should include type hints.
+    *   Run `mypy src/twat_cache tests`
+*   **Imports:** `isort` (via Ruff) is used to sort imports. Known first-party is `twat_cache`. Relative imports are generally banned in `src` but allowed in `tests`.
+*   **Line Length:** 88 characters, enforced by Black/Ruff.
+
+**Dependencies:**
+
+*   **Core:** `pydantic` (for configuration), `loguru` (for logging), `diskcache`, `joblib`, `cachetools`.
+*   **Optional Backend Libraries & Their Engines:**
+    *   `cachebox` (for `CacheBoxEngine`)
+    *   `aiocache` (for `AioCacheEngine`)
+    *   `klepto` (for `KleptoEngine`)
+    These are installed via extras like `twat-cache[all]` or `twat-cache[cachebox]`.
+*   **Development & Testing:** `pytest`, `pytest-cov`, `pytest-benchmark`, `mypy`, `ruff`, `hatch`, `pre-commit`.
+
+**Testing:**
+
+*   Tests are located in the `tests/` directory and use `pytest`.
+*   Run tests with `python -m pytest -n auto tests` (or via `hatch env run test:test`).
+*   Coverage is monitored: `python -m pytest -n auto --cov=src/twat_cache ...` (or `hatch env run test:test-cov`).
+*   Strive for high test coverage for new features and bug fixes.
+*   Benchmarks are present in `tests/test_benchmark.py` and can be run with `pytest-benchmark`.
+
+**Contribution Process:**
+
+1.  **Fork the repository** on GitHub.
+2.  **Create a new branch** for your feature or bug fix: `git checkout -b feature/your-feature-name` or `bugfix/issue-description`.
+3.  **Make your changes.** Ensure you add tests for any new functionality or bug fixes.
+4.  **Run linters, formatters, and type checkers locally:**
+    *   `hatch env run lint:fmt` (or `ruff format . && ruff check --fix .`)
+    *   `hatch env run lint:typing` (or `mypy src/twat_cache tests`)
+    *   Or use `pre-commit` hooks.
+5.  **Run tests:** `hatch env run test:test` (or `pytest -n auto tests`)
+6.  **Commit your changes** with a clear and descriptive commit message.
+7.  **Push your branch** to your fork: `git push origin feature/your-feature-name`.
+8.  **Open a Pull Request (PR)** against the main branch of the original repository.
+9.  Address any feedback or CI failures.
+
+**Pre-commit Hooks:**
+
+The project uses `pre-commit` (as indicated by `.pre-commit-config.yaml`) to automatically run linters and formatters before commits. Install and set it up in your local clone:
+
+```bash
+pip install pre-commit
+pre-commit install
 ```
 
-### Hybrid Caching
-
-Switch backends based on result size:
-
-```python
-from twat_cache import hybrid_cache
-
-@hybrid_cache()
-def get_data(size: str) -> Union[Dict[str, Any], List[int]]:
-    """Return different sized data with appropriate backend selection."""
-    if size == "small":
-        # Small result, will use in-memory caching
-        return {"name": "Small Data", "value": 42}
-    else:
-        # Large result, will use disk caching
-        return [i for i in range(100000)]
-```
-
-### Type-Specific Configuration
-
-Configure caching based on data types:
-
-```python
-from twat_cache import ucache, configure_for_numpy, configure_for_json
-
-# For NumPy arrays
-@ucache(config=configure_for_numpy())
-def process_array(data: np.ndarray) -> np.ndarray:
-    return data * 2
-
-# For JSON data
-@ucache(config=configure_for_json())
-def fetch_json_data(url: str) -> Dict[str, Any]:
-    return {"data": [1, 2, 3, 4, 5], "metadata": {"source": url}}
-```
-
-### Cache Management
-
-Clear caches and get statistics:
-
-```python
-from twat_cache import clear_cache, get_stats
-
-# Clear all caches
-clear_cache()
-
-# Get cache statistics
-stats = get_stats()
-print(stats)  # Shows hits, misses, size, etc.
-```
-
-### Context Management
-
-Use cache engines with context management:
-
-```python
-from twat_cache import CacheContext, engine_context
-
-# Method 1: Using the CacheContext class
-with CacheContext(engine_name="diskcache", folder_name="cache") as cache:
-    # Use the cache
-    cache.set("key", "value")
-    value = cache.get("key")
-    
-# Method 2: Using the engine_context function
-with engine_context(engine_name="redis", ttl=3600) as cache:
-    # Use the cache
-    cache.set("key", "value")
-    value = cache.get("key")
-    
-# Cache is automatically closed when exiting the context
-```
-
-## Advanced Features
-
-### TTL Support
-
-Set time-to-live for cache entries:
-
-```python
-from twat_cache import ucache
-
-@ucache(ttl=3600)  # Entries expire after 1 hour
-def get_weather(city: str) -> dict:
-    # Fetch weather data
-    return {"temp": 20}
-```
-
-### Eviction Policies
-
-Choose from different cache eviction policies:
-
-```python
-from twat_cache import ucache
-
-# Least Recently Used (default)
-@ucache(policy="lru")
-def function1(x: int) -> int:
-    return x * x
-
-# Least Frequently Used
-@ucache(policy="lfu")
-def function2(x: int) -> int:
-    return x * x
-
-# First In, First Out
-@ucache(policy="fifo")
-def function3(x: int) -> int:
-    return x * x
-```
-
-## Documentation
-
-For more detailed documentation, see the following resources:
-
-- [Context Management](docs/context_management.md)
-- [Backend Selection](docs/backend_selection.md)
-- [Cache Engines](docs/cache_engines.md)
-- [Configuration Options](docs/configuration.md)
-- [API Reference](docs/api_reference.md)
-
-## Contributing
-
-Contributions are welcome! Please feel free to submit a Pull Request.
-
-## License
-
-This project is licensed under the MIT License - see the LICENSE file for details.
-
-## Rationale
-
-Python provides several powerful caching libraries to help optimize application performance by storing and reusing expensive function results. Let's take an in-depth look at some of the most popular options, comparing their features, backends, methods, and use cases.
-
-
-### Built-in functools 
-
-Python's standard library offers basic caching functionality through the `functools` module. It provides decorators like `@lru_cache(maxsize, typed)` for simple memoization with a Least Recently Used (LRU) eviction policy. The `@cache` decorator is also available, which is equivalent to an unbounded LRU cache.
-
-- **Backend**: In-memory Python dictionary 
-- **Eviction Policy**: LRU or unbounded
-- **Concurrency**: Thread-safe via internal locks, but not safe for multi-process use
-- **Persistence**: No persistence, cache only exists in memory for the lifetime of the process
-- **Best For**: Fast and easy caching of function results in memory with minimal setup
-
-```pyi
-### functools.pyi (Partial - Caching related parts)
-
-import typing
-
-_T = typing.TypeVar("_T")
-
-@typing.overload
-def lru_cache(maxsize: int | None) -> typing.Callable[[_F], _F]: ...
-@typing.overload
-def lru_cache(maxsize: int | None, typed: bool) -> typing.Callable[[_F], _F]: ...
-
-class _lru_cache_wrapper(typing.Generic[_F]):
-    cache: typing.Dict[typing.Tuple[typing.Any, ...], typing.Any]
-    def cache_info(self) -> CacheInfo: ...
-    def cache_clear(self) -> None: ...
-```
-
-```python
-import functools
-
-@functools.lru_cache(maxsize=128)
-def expensive_function(x):
-    return x * 2
-```
-
-### cachetools
-
-The `cachetools` library extends the capabilities of `functools` by offering additional cache classes with various eviction policies like LFU, FIFO, TTL, and RR. It also provides `@cached` and `@cachedmethod` decorators for caching functions and methods.
-
-- **Backend**: In-memory Python dictionary
-- **Eviction Policies**: LRU, LFU, TTL, FIFO, RR, TLRU 
-- **Concurrency**: Thread-safe, not designed for multi-process use
-- **Persistence**: In-memory only, no persistence 
-- **Customization**: Configurable `maxsize`, `ttl`, custom `getsizeof` to determine item size
-- **Best For**: In-memory caching with specific eviction behavior, e.g. caching web API responses
-
-```pyi
-### cachetools.pyi (Partial - Most important classes and decorators)
-
-import typing
-from typing import Callable
-
-KT = typing.TypeVar("KT")
-VT = typing.TypeVar("VT")
-DT = typing.TypeVar("DT")
-
-class Cache(typing.MutableMapping[KT, VT]):
-    def __init__(self, maxsize: int, getsizeof: Callable[[VT], int] | None = ...) -> None: ...
-    @property
-    def maxsize(self) -> int: ...
-    @property
-    def currsize(self) -> int: ...
-    def get(self, key: KT, default: DT = ...) -> VT | DT: ...
-    def pop(self, key: KT, default: DT = ...) -> VT | DT: ...
-    def setdefault(self, key: KT, default: DT = ...) -> VT | DT: ...
-    def clear(self) -> None: ...
-    @staticmethod
-    def getsizeof(value: Any) -> int: ...
-
-class LRUCache(Cache[KT, VT]):
-    def __init__(self, maxsize: int, getsizeof: Callable[[VT], int] | None = ...) -> None: ...
-    def popitem(self) -> tuple[KT, VT]: ...
-
-class LFUCache(Cache[KT, VT]):
-    def __init__(self, maxsize: int, getsizeof: Callable[[VT], int] | None = ...) -> None: ...
-    def popitem(self) -> tuple[KT, VT]: ...
-
-class TTLCache(LRUCache[KT, VT]):
-    def __init__(self, maxsize: int, ttl: int, timer: Callable[[], float] | None = ..., getsizeof: Callable[[VT], int] | None = ...) -> None: ...
-    @property
-    def ttl(self) -> int: ...
-    def expire(self, time: float | None = ...) -> list[tuple[KT, VT]]: ...
-    def popitem(self) -> tuple[KT, VT]: ...
-
-class _CacheInfo(NamedTuple):
-    hits: int
-    misses: int
-    maxsize: int
-    currsize: int
-
-_KeyFunc = Callable[..., typing.Hashable]
-_Cache = TypeVar("_Cache", bound=Cache)
-
-@overload
-def cached(
-    cache: _Cache,
-    key: _KeyFunc = ...,
-    lock: Any | None = ...,
-    info: Literal[False] = ...,
-) -> Callable[[_F], _F]: ...
-@overload
-def cached(
-    cache: _Cache,
-    key: _KeyFunc = ...,
-    lock: Any | None = ...,
-    info: Literal[True] = ...,
-) -> Callable[[_F], _F]: ...
-
-@overload
-def cachedmethod(
-    cache: Callable[[Any], _Cache],
-    key: _KeyFunc = ...,
-    lock: Callable[[Any], Any] | None = ...,
-) -> Callable[[_F], _F]: ...
-@overload
-def cachedmethod(
-    cache: Callable[[Any], _Cache],
-    key: _KeyFunc = ...,
-    lock: None = ...,
-) -> Callable[[_F], _F]: ...
-```
-
-### cachebox
-
-`cachebox` is an in-memory caching solution accelerated by a Rust backend for enhanced performance. It supports similar eviction policies as `cachetools` including a unique variable TTL cache.
-
-- **Backend**: Rust-backed in-memory store
-- **Eviction Policies**: LRU, LFU, FIFO, TTL, RR, variable TTL
-- **Concurrency**: Thread-safe Rust implementation, but in-memory only
-- **Decorators**: `@cached`, `@cachedmethod` support custom key generation and callbacks
-- **Best For**: Performant in-memory caching with ample policy choices
-
-```pyi
-### cachebox.pyi (Partial - Most important classes)
-
-import typing
-
-KT = typing.TypeVar("KT")
-VT = typing.TypeVar("VT")
-DT = typing.TypeVar("DT")
-
-
-class BaseCacheImpl(Generic[KT, VT]):
-
-    def __init__(
-        self,
-        maxsize: int,
-        iterable: Union[Iterable[Tuple[KT, VT]], Dict[KT, VT]] = ...,
-        *,
-        capacity: int = ...,
-    ) -> None: ...
-    @property
-    def maxsize(self) -> int: ...
-    def __len__(self) -> int: ...
-    def __contains__(self, key: KT) -> bool: ...
-    def __setitem__(self, key: KT, value: VT) -> None: ...
-    def __getitem__(self, key: KT) -> VT: ...
-    def __delitem__(self, key: KT) -> VT: ...
-    def __iter__(self) -> typing.Iterator[KT]: ...
-    def capacity(self) -> int: ...
-    def is_full(self) -> bool: ...
-    def is_empty(self) -> bool: ...
-    def insert(self, key: KT, value: VT) -> typing.Optional[VT]: ...
-    def get(self, key: KT, default: DT = None) -> typing.Union[VT, DT]: ...
-    def pop(self, key: KT, default: DT = None) -> typing.Union[VT, DT]: ...
-    def setdefault(
-        self, key: KT, default: typing.Optional[DT] = None
-    ) -> typing.Optional[VT | DT]: ...
-    def popitem(self) -> typing.Tuple[KT, VT]: ...
-    def drain(self, n: int) -> int: ...
-    def clear(self, *, reuse: bool = False) -> None: ...
-    def shrink_to_fit(self) -> None: ...
-    def update(
-        self, iterable: typing.Union[typing.Iterable[typing.Tuple[KT, VT]], typing.Dict[KT, VT]]
-    ) -> None: ...
-    def keys(self) -> typing.Iterable[KT]: ...
-    def values(self) -> typing.Iterable[VT]: ...
-    def items(self) -> typing.Iterable[typing.Tuple[KT, VT]]: ...
-
-class Cache(BaseCacheImpl[KT, VT]):
-    def __init__(
-        self,
-        maxsize: int,
-        iterable: Union[Iterable[Tuple[KT, VT]], Dict[KT, VT]] = ...,
-        *,
-        capacity: int = ...,
-    ) -> None:
-        ...
-    def popitem(self) -> typing.NoReturn: ...  # not implemented for this class
-    def drain(self, n: int) -> typing.NoReturn: ...  # not implemented for this class
-
-
-class FIFOCache(BaseCacheImpl[KT, VT]):
-    def __init__(
-        self,
-        maxsize: int,
-        iterable: Union[Iterable[Tuple[KT, VT]], Dict[KT, VT]] = ...,
-        *,
-        capacity: int = ...,
-    ) -> None:
-        ...
-
-class RRCache(BaseCacheImpl[KT, VT]):
-    def __init__(
-        self,
-        maxsize: int,
-        iterable: Union[Iterable[Tuple[KT, VT]], Dict[KT, VT]] = ...,
-        *,
-        capacity: int = ...,
-    ) -> None:
-        ...
-
-class TTLCache(BaseCacheImpl[KT, VT]):
-    def __init__(
-        self,
-        maxsize: int,
-        ttl: float,
-        iterable: Union[Iterable[Tuple[KT, VT]], Dict[KT, VT]] = ...,
-        *,
-        capacity: int = ...,
-    ) -> None:
-        ...
-
-class LRUCache(BaseCacheImpl[KT, VT]):
-    def __init__(
-        self,
-        maxsize: int,
-        iterable: Union[Iterable[Tuple[KT, VT]], Dict[KT, VT]] = ...,
-        *,
-        capacity: int = ...,
-    ) -> None:
-        ...
-
-class LFUCache(BaseCacheImpl[KT, VT]):
-    def __init__(
-        self,
-        maxsize: int,
-        iterable: Union[Iterable[Tuple[KT, VT]], Dict[KT, VT]] = ...,
-        *,
-        capacity: int = ...,
-    ) -> None:
-        ...
-
-class VTTLCache(BaseCacheImpl[KT, VT]):
-    def __init__(
-        self,
-        maxsize: int,
-        iterable: Union[Iterable[Tuple[KT, VT]], Dict[KT, VT]] = ...,
-        ttl: Optional[float] = 0.0,
-        *,
-        capacity: int = ...,
-    ) -> None:
-        ...
-
-_CacheType = TypeVar("_CacheType", bound=BaseCacheImpl)
-
-def cached(cache: typing.Optional[_CacheType], key_maker: typing.Optional[Callable[[tuple, dict], typing.Hashable]] = ..., clear_reuse: bool = ..., callback: typing.Optional[Callable[[int, typing.Any, typing.Any], typing.Any]] = ..., copy_level: int = ..., always_copy: typing.Optional[bool] = ...) -> Callable[[_F], _F]: ...
-def cachedmethod(cache: typing.Optional[_CacheType], key_maker: typing.Optional[Callable[[tuple, dict], typing.Hashable]] = ..., clear_reuse: bool = ..., callback: typing.Optional[Callable[[int, typing.Any, typing.Any], typing.Any]] = ..., copy_level: int = ..., always_copy: typing.Optional[bool] = ...) -> Callable[[_F], _F]: ...
-```
-
-### klepto
-
-For advanced caching workflows, `klepto` provides a highly flexible solution supporting both in-memory and persistent backends like file archives, SQL databases, and HDF5 files. It allows customizing how cache keys are generated and extends the standard cache eviction policies.
-
-- **Backends**: In-memory dict, file archives, SQL databases, HDF5 files
-- **Eviction Policies**: Same as `functools` plus LFU, MRU, RR
-- **Key Mapping**: `hashmap`, `stringmap`, `picklemap` algorithms to generate keys
-- **Persistence**: Archives cache to disk or database for long-term storage
-- **Concurrency**: Locking for thread-safety, some process-safety depending on backend
-- **Best For**: Complex scenarios needing transient and persistent caching
-
-```pyi
-### key maps
-class keymap:
-    def __init__(self, typed: bool = False, flat: bool = True,
-                 sentinel: object=...) -> None: ...
-    def __call__(self, *args, **kwargs) -> object: ...
-
-class hashmap(keymap):
-    def __init__(self, algorithm: Optional[str] = None,
-                 typed: bool = False, flat: bool = True,
-                 sentinel: object=...) -> None: ...
-
-class stringmap(keymap):
-    def __init__(self, encoding: Optional[str] = None,
-                 typed: bool = False, flat: bool = True,
-                 sentinel: object=...) -> None: ...
-
-class picklemap(keymap):
-    def __init__(self, serializer: Optional[str] = None,
-                 typed: bool = False, flat: bool = True,
-                 sentinel: object=...) -> None: ...
-
-### base archive
-class archive(dict):
-    def __init__(self, *args, **kwds) -> None: ...
-    def __asdict__(self) -> dict: ...
-    def __repr__(self) -> str: ...
-    def copy(self, name: Optional[str] = None) -> 'archive': ...
-    def load(self, *args) -> None: ...
-    def dump(self, *args) -> None: ...
-    def archived(self, *on) -> bool: ...
-    def sync(self, clear: bool = False) -> None: ...
-    def drop(self) -> None: ...
-    def open(self, archive: 'archive') -> None: ...
-
-    @property
-    def archive(self) -> 'archive': ...
-    @archive.setter
-    def archive(self, archive: 'archive') -> None: ...
-    @property
-    def name(self) -> str: ...
-    @name.setter
-    def name(self, archive: 'archive') -> None: ...
-    @property
-    def state(self) -> dict: ...
-    @state.setter
-    def state(self, archive: 'archive') -> None: ...
-
-class dict_archive(archive):
-    def __init__(self, *args, **kwds) -> None: ...
-
-class null_archive(archive):
-    def __init__(self, *args, **kwds) -> None: ...
-
-class file_archive(archive):
-    def __init__(self, filename: Optional[str] = None, dict: Optional[dict] = None,
-                 cached: bool = True, serialized: bool = True,
-                 protocol: Optional[int] = None, *args, **kwds) -> None: ...
-
-class dir_archive(archive):
-    def __init__(self, dirname: Optional[str] = None, dict: Optional[dict] = None,
-                 cached: bool = True, serialized: bool = True,
-                 compression: int = 0, permissions: Optional[int] = None,
-                 memmode: Optional[str] = None, memsize: int = 100,
-                 protocol: Optional[int] = None, *args, **kwds) -> None: ...
-
-class sqltable_archive(archive):
-    def __init__(self, database: Optional[str] = None,
-                 table: Optional[str] = None, dict: Optional[dict] = None,
-                 cached: bool = True, serialized: bool = True,
-                 protocol: Optional[int] = None, *args, **kwds) -> None: ...
-
-class sql_archive(archive):
-    def __init__(self, database: Optional[str] = None, dict: Optional[dict] = None,
-                 cached: bool = True, serialized: bool = True,
-                 protocol: Optional[int] = None, *args, **kwds) -> None: ...
-
-class hdfdir_archive(archive):
-    def __init__(self, dirname: Optional[str] = None, dict: Optional[dict] = None,
-                 cached: bool = True, serialized: bool = True,
-                 permissions: Optional[int] = None,
-                 protocol: Optional[int] = None, *args, **kwds) -> None: ...
-
-class hdf_archive(archive):
-    def __init__(self, filename: Optional[str] = None, dict: Optional[dict] = None,
-                 cached: bool = True, serialized: bool = True,
-                 protocol: Optional[int] = None, *args, **kwds) -> None: ...
-```
-
-### diskcache
-
-When caching large datasets that should survive process restarts, `diskcache` shines with its optimized disk-backed storage using SQLite and the filesystem. It offers a range of eviction policies, a sharded `FanoutCache`, and persistent data structures like `Deque` and `Index`.
-
-- **Backend**: SQLite for metadata, filesystem for data
-- **Eviction Policies**: Configurable, including LRU and LFU
-- **Persistence**: Data persists on disk between process runs
-- **Concurrency**: Thread and process-safe 
-- **Added Features**: Stampede prevention, throttling, optimized I/O
-- **Best For**: Persistent caching for web apps and data pipelines
-
-```pyi
-### diskcache.pyi (Partial - Most important classes)
-
-import typing
-from typing import Callable, List, Dict, Any, IO, Optional, Tuple, Union
-
-class Cache:
-    def __init__(self, directory: Optional[str] = ..., timeout: float = ..., disk: Type[Disk] = ..., **settings: Any) -> None: ...
-    @property
-    def directory(self) -> str: ...
-    @property
-    def timeout(self) -> float: ...
-    @property
-    def disk(self) -> Disk: ...
-    def set(self, key: Any, value: Any, expire: Optional[float] = ..., read: bool = ..., tag: Optional[str] = ..., retry: bool = ...) -> bool: ...
-    def get(self, key: Any, default: Optional[Any] = ..., read: bool = ..., expire_time: bool = ..., tag: bool = ..., retry: bool = ...) -> Any: ...
-    def delete(self, key: Any, retry: bool = ...) -> bool: ...
-    def clear(self, retry: bool = ...) -> int: ...
-    def volume(self) -> int: ...
-    def check(self, fix: bool = ..., retry: bool = ...) -> List[warnings.WarningMessage]: ...
-    def transact(self, retry: bool = ...) -> ContextManager[Callable]: ...
-    def memoize(self, name: Optional[str] = ..., typed: bool = ..., expire: Optional[float] = ..., tag: Optional[str] = ..., ignore: typing.Iterable[str] = ...) -> Callable[[_F], _F]: ...
-    def close(self) -> None: ...
-    def volume(self) -> int: ...
-    def stats(self, enable: bool = ..., reset: bool = ...) -> Tuple[int, int]: ...
-    def volume(self) -> int: ...
-
-class FanoutCache:
-    def __init__(self, directory: Optional[str] = ..., shards: int = ..., timeout: float = ..., disk: Type[Disk] = ..., **settings: Any) -> None: ...
-    @property
-    def directory(self) -> str: ...
-    def transact(self, retry: bool = ...) -> ContextManager[Callable]: ...
-    def set(self, key: Any, value: Any, expire: Optional[float] = ..., read: bool = ..., tag: Optional[str] = ..., retry: bool = ...) -> bool: ...
-    def get(self, key: Any, default: Optional[Any] = ..., read: bool = ..., expire_time: bool = ..., tag: bool = ..., retry: bool = ...) -> Any: ...
-    def delete(self, key: Any, retry: bool = ...) -> bool: ...
-    def clear(self, retry: bool = ...) -> int: ...
-    def volume(self) -> int: ...
-    def stats(self, enable: bool = ..., reset: bool = ...) -> Tuple[int, int]: ...
-    def memoize(self, name: Optional[str] = ..., typed: bool = ..., expire: Optional[float] = ..., tag: Optional[str] = ..., ignore: typing.Iterable[str] = ...) -> Callable[[_F], _F]: ...
-    def close(self) -> None: ...
-    def volume(self) -> int: ...
-
-class Disk:
-    def __init__(self, directory: str, min_file_size: int = ..., pickle_protocol: int = ...) -> None: ...
-    @property
-    def min_file_size(self) -> int: ...
-    @property
-    def pickle_protocol(self) -> int: ...
-    def put(self, key: Any) -> Tuple[Union[str, sqlite3.Binary, int, float], bool]: ...
-    def get(self, key: Union[str, sqlite3.Binary, int, float], raw: bool) -> Any: ...
-    def store(self, value: Any, read: bool, key: Constant = ...) -> Tuple[int, int, Optional[str], Optional[Union[str, sqlite3.Binary, int, float]]]: ...
-    def fetch(self, mode: int, filename: Optional[str], value: Optional[Union[str, sqlite3.Binary, int, float]], read: bool) -> Any: ...
-
-class JSONDisk(Disk):
-    def __init__(self, directory: str, compress_level: int = ..., **kwargs: Any) -> None: ...
-```
-
-### joblib
-
-Designed for scientific computing and ML workflows, `joblib` offers transparent disk-caching for functions, with optimizations for large NumPy arrays. Results are saved to disk and only re-computed when inputs change.
-
-- **Backend**: Filesystem
-- **Persistence**: Caches results to disk for costly computations
-- **Memoization**: `@memory.cache` decorator for functions
-- **Serialization**: Pickle-based with optional compression
-- **Concurrency**: Process-safe file locking
-- **Best For**: Caching ML models, features, large NumPy arrays
-
-```pyi
-### joblib.pyi (Partial - Most important classes and functions)
-
-import typing
-from typing import Callable, List, Dict, Any, IO, Optional, Tuple, Union
-
-_F = TypeVar("_F", bound=Callable[..., Any])
-
-class Memory:
-    def __init__(self, location: Optional[str] = ..., backend: str = ..., verbose: int = ..., bytes_limit: Optional[Union[int, str]] = ..., mmap_mode: Optional[str] = ..., compress: Union[bool, int] = ..., backend_options: Optional[Dict[str, Any]] = ...) -> None: ...
-    @property
-    def location(self) -> str: ...
-    @property
-    def backend(self) -> str: ...
-    @property
-    def compress(self) -> Union[bool, int]: ...
-    @property
-    def verbose(self) -> int: ...
-    def cache(self, func: Optional[_F] = ..., ignore: Optional[List[str]] = ..., verbose: Optional[int] = ..., mmap_mode: Optional[str] = ..., cache_validation_callback: Optional[Callable[[Dict[str, Any]], bool]] = ...) -> _F: ...
-    def clear(self, warn: bool = ...) -> None: ...
-    def eval(self, func: _F, *args: Any, **kwargs: Any) -> Any: ...
-    def __call__(self, func: _F, *args: Any, **kwargs: Any) -> Any: ...
-
-class Parallel:
-    def __init__(self, n_jobs: Optional[int] = ..., backend: Optional[str] = ..., verbose: int = ..., timeout: Optional[float] = ..., pre_dispatch: Union[str, int] = ..., batch_size: Union[str, int] = ..., temp_folder: Optional[str] = ..., max_nbytes: Optional[Union[int, str]] = ..., mmap_mode: Optional[str] = ..., prefer: Optional[str] = ..., require: Optional[str] = ...) -> None: ...
-    def __call__(self, iterable: typing.Iterable) -> List[Any]: ...
-    def __enter__(self) -> "Parallel": ...
-    def __exit__(self, exc_type: Optional[Type[BaseException]], exc_value: Optional[BaseException], traceback: Optional[TracebackType]) -> None: ...
-    def submit(self, func: _F, *args: Any, **kwargs: Any) -> concurrent.futures.Future: ...
-    def map(self, func: _F, *iterables: typing.Iterable, timeout: Optional[float] = ..., chunksize: int = ...) -> typing.Iterable[Any]: ...
-    def dispatch_next(self) -> None: ...
-    def print_progress(self) -> None: ...
-    def clear(self) -> None: ...
-    def __len__(self) -> int: ...
-
-def delayed(function: _F) -> Callable[..., Tuple[Callable, tuple, dict]]: ...
-def cpu_count(only_physical_cores: bool = ...) -> int: ...
-def effective_n_jobs(n_jobs: int = ...) -> int: ...
-def hash(obj: Any, hash_name: str = ..., coerce_mmap: bool = ...) -> str: ...
-def dump(value: Any, filename: Union[str, PathLikeStr], compress: Union[bool, int] = ..., protocol: Optional[int] = ..., cache_size: Optional[int] = ...) -> List[str]: ...
-def load(filename: Union[str, PathLikeStr], mmap_mode: Optional[str] = ...) -> Any: ...
-def register_parallel_backend(name: str, factory: Callable[..., ParallelBackendBase], make_default: bool = ...) -> None: ...
-
-#### aiocache
-
-Built for async applications using the `asyncio` framework, `aiocache` enables non-blocking caching operations. It provides both in-memory (`SimpleMemoryCache`) and distributed options (`RedisCache`, `MemcachedCache`).
-
-- **Backends**: In-memory, Redis, Memcached
-- **Async Decorators**: `@cached`, `@cached_stampede`, `@multi_cached`  
-- **Serialization**: Pluggable, defaults to JSON
-- **Best For**: Asynchronous web frameworks (FastAPI, Sanic), distributed caching
-
-```pyi
-### aiocache.pyi (Partial - Most important classes and decorators)
-
-import typing
-from typing import Any, Callable, Coroutine, Dict, List, Optional, Tuple, Type, Union
-
-_F = typing.TypeVar("_F", bound=Callable[..., Any])
-
-class BaseCache:
-    NAME: str
-    def __init__(self, serializer: Optional[BaseSerializer] = ..., plugins: Optional[List[BasePlugin]] = ..., namespace: Optional[str] = ..., timeout: float = ..., ttl: Optional[int] = ...) -> None: ...
-    @classmethod
-    def parse_uri_path(cls, path: str) -> Dict[str, str]: ...
-    async def add(self, key: str, value: Any, ttl: Optional[int] = ..., dumps_fn: Optional[Callable[[Any], bytes]] = ..., namespace: Optional[str] = ..., timeout: Optional[int] = ...) -> bool: ...
-    async def get(self, key: str, default: Optional[Any] = ..., loads_fn: Optional[Callable[[bytes], Any]] = ..., namespace: Optional[str] = ..., timeout: Optional[int] = ...) -> Any: ...
-    async def multi_get(self, keys: List[str], loads_fn: Optional[Callable[[bytes], Any]] = ..., namespace: Optional[str] = ..., timeout: Optional[int] = ...) -> List[Any]: ...
-    async def set(self, key: str, value: Any, ttl: Optional[int] = ..., dumps_fn: Optional[Callable[[Any], bytes]] = ..., namespace: Optional[str] = ..., timeout: Optional[int] = ..., _cas_token: Optional[Any] = ...) -> bool: ...
-    async def multi_set(self, pairs: List[Tuple[str, Any]], ttl: Optional[int] = ..., dumps_fn: Optional[Callable[[Any], bytes]] = ..., namespace: Optional[str] = ..., timeout: Optional[int] = ...) -> bool: ...
-    async def delete(self, key: str, namespace: Optional[str] = ..., timeout: Optional[int] = ...) -> int: ...
-    async def exists(self, key: str, namespace: Optional[str] = ..., timeout: Optional[int] = ...) -> bool: ...
-    async def increment(self, key: str, delta: int = ..., namespace: Optional[str] = ..., timeout: Optional[int] = ...) -> int: ...
-    async def expire(self, key: str, ttl: Optional[int] = ..., namespace: Optional[str] = ..., timeout: Optional[int] = ...) -> bool: ...
-    async def clear(self, namespace: Optional[str] = ..., timeout: Optional[int] = ...) -> bool: ...
-    async def close(self, timeout: Optional[int] = ...) -> bool: ...
-    async def raw(self, command: str, *args: Any, encoding: Optional[str] = ..., timeout: Optional[int] = ..., **kwargs: Any) -> Any: ...
-
-class SimpleMemoryCache(BaseCache):
-    NAME: str
-    def __init__(self, serializer: Optional[BaseSerializer] = ..., **kwargs: Any) -> None: ...
-
-class RedisCache(BaseCache):
-    NAME: str
-    def __init__(self, serializer: Optional[BaseSerializer] = ..., **kwargs: Any) -> None: ...
-
-class MemcachedCache(BaseCache):
-    NAME: str
-    def __init__(self, serializer: Optional[BaseSerializer] = ..., **kwargs: Any) -> None: ...
-
-class BaseSerializer:
-    DEFAULT_ENCODING: Optional[str]
-    def __init__(self, *args: Any, encoding: Union[str, object] = ..., **kwargs: Any) -> None: ...
-    def dumps(self, value: Any) -> bytes: ...
-    def loads(self, value: bytes) -> Any: ...
-
-class JsonSerializer(BaseSerializer):
-    def dumps(self, value: Any) -> str: ...
-    def loads(self, value: str) -> Any: ...
-
-class PickleSerializer(BaseSerializer):
-    def dumps(self, value: Any) -> bytes: ...
-    def loads(self, value: bytes) -> Any: ...
-
-class NullSerializer(BaseSerializer):
-    def dumps(self, value: Any) -> Any: ...
-    def loads(self, value: Any) -> Any: ...
-
-class BasePlugin:
-    async def pre_get(self, client: BaseCache, key: str, namespace: Optional[str], **kwargs: Any) -> None: ...
-    async def post_get(self, client: BaseCache, key: str, namespace: Optional[str], rv: Any, **kwargs: Any) -> None: ...
-    # ... (and similar methods for other cache operations)
-
-_Cache = TypeVar("_Cache", bound=BaseCache)
-
-def cached(
-    ttl: Optional[int] = ...,
-    key: Optional[str] = ...,
-    key_builder: Optional[Callable[..., str]] = ...,
-    namespace: Optional[str] = ...,
-    cache: Union[Type[_Cache], str] = ...,
-    serializer: Optional[BaseSerializer] = ...,
-    plugins: Optional[List[BasePlugin]] = ...,
-    alias: Optional[str] = ...,
-    noself: bool = ...,
-    skip_cache_func: Optional[Callable[[Any], bool]] = ...,
-    **kwargs: Any
-) -> Callable[[_F], _F]: ...
-
-def cached_stampede(
-    lease: int = ...,
-    ttl: Optional[int] = ...,
-    key: Optional[str] = ...,
-    key_builder: Optional[Callable[..., str]] = ...,
-    namespace: Optional[str] = ...,
-    cache: Union[Type[_Cache], str] = ...,
-    serializer: Optional[BaseSerializer] = ...,
-    plugins: Optional[List[BasePlugin]] = ...,
-    alias: Optional[str] = ...,
-    noself: bool = ...,
-    skip_cache_func: Optional[Callable[[Any], bool]] = ...,
-    **kwargs: Any
-) -> Callable[[_F], _F]: ...
-
-def multi_cached(
-    keys_from_attr: Optional[str] = ...,
-    namespace: Optional[str] = ...,
-    key_builder: Optional[Callable[..., str]] = ...,
-    ttl: Optional[int] = ...,
-    cache: Union[Type[_Cache], str] = ...,
-    serializer: Optional[BaseSerializer] = ...,
-    plugins: Optional[List[BasePlugin]] = ...,
-    alias: Optional[str] = ...,
-    skip_cache_func: Optional[Callable[[str, Any], bool]] = ...,
-    **kwargs: Any
-) -> Callable[[_F], _F]: ...
-```
-
-### Summary of type hints
-
-```pyi
-### Type Stubs for Caching Libraries
-
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    Type,
-    Iterable,
-    Tuple,
-    Union,
-    TypeVar,
-    Generic,
-)
-import datetime
-import logging
-from typing_extensions import Literal  # For older Python versions
-```
-
-*   **Generics:** For generic types like `Cache`, `FIFOCache`, `LFUCache`, etc. (in `cachetools`, `cachebox`, `klepto`) , I've used `TypeVar` to represent the key (`KT`) and value (`VT`) types.  This gives better type hinting.
-*   **`object` as Default:** Where the original code uses implicit dynamic typing (no explicit type) or uses an internal implementation detail, I've often used `object` as the most general type hint.  This avoids creating stubs for internal classes.
-*   **`NotImplementedError` and `typing.NoReturn`:** I've used `typing.NoReturn` for methods that are *not implemented* in a base class.  This is more precise than raising `NotImplementedError`, which would imply that a subclass *should* implement it.
-*   **`defaultdict`:**  I've handled cases where `defaultdict` is used internally, providing a default factory function.
-*   **`_Conn`:**  This internal helper class from `aiocache` is fully defined as all its methods are based on exported API.
-* **`_DISTUTILS_PATCH`, `VIRTUALENV_PATCH_FILE`, etc.:** These internal constants/classes, used for patching `distutils`, are omitted.
-*   **`kwargs` Handling:** In many cases, I've used `**kwargs` to represent arbitrary keyword arguments, especially when those arguments are passed directly to another function (like `open` or a backend-specific constructor).
-* **`functools`:** The return type of decorators (`lru_cache`, `cache`) is `Callable[[Callable[..., R]], Callable[..., R]]`.  I've used a `TypeVar` named `_R` to make the relationship between the input and output types clear.
-* **`klepto` classes**: Added the API for the `archive`, `dir_archive`, `sql_archive`, `sqltable_archive` based on the source code.
-* **`joblib` classes**: Added the classes in the public API, `Memory`, `MemorizedFunc`, `NotMemorizedFunc`.
-
-#### Recommendations
-
-The best caching library depends on your specific needs - whether you require persistence, have large datasets, need multi-process safety, or are using an async framework. By understanding the strengths of each library, you can make an informed choice to optimize your application's performance.
-
+This helps ensure that contributions meet the project's coding standards.
+
+**Logging:**
+
+The `loguru` library is used for logging. Import the logger from `twat_cache.logging` for consistent logging within the library.
+
+**Project Structure (`src/twat_cache`):**
+
+*   `__init__.py`: Exports main public interface (decorators, context managers).
+*   `__main__.py`: Contains some utility functions, but not a primary CLI entry point for the cache library itself.
+*   `cache.py`: Global cache registration and management utilities.
+*   `config.py`: `CacheConfig` Pydantic model and configuration factory.
+*   `context.py`: `CacheContext` and `engine_context` for explicit cache management.
+*   `decorators.py`: Core caching decorators (`mcache`, `bcache`, etc.) and backend selection logic.
+*   `engines/`: Directory for different cache backend implementations.
+    *   `base.py`: `BaseCacheEngine` protocol.
+    *   `manager.py`: `CacheEngineManager`.
+    *   Individual engine files (e.g., `diskcache.py`, `joblib.py`).
+*   `exceptions.py`: Custom exceptions.
+*   `logging.py`: Logging setup.
+*   `paths.py`: Path utilities (though `__main__.py` also has some path logic).
+*   `type_defs.py`: Common type definitions and protocols.


### PR DESCRIPTION
Rewrite the README.md to be a highly informative and detailed one-page documentation.

The first part is accessible for wider audiences and describes:
- What the tool does
- Who it's for
- Why it's useful
- How to install it (basic, all, specific backends)
- How to use it programmatically (with examples for mcache, bcache, fcache, acache, ucache, and CacheContext)
- Clarifies that there is no direct user-facing CLI.

The second part is highly technical and detailed, describing:
- How the code works precisely (decorators, configuration, cache engines and manager, cache management utilities, context management, backend selection logic, key generation).
- Rules of coding and contributing (coding conventions, style, dependencies, testing, contribution process, pre-commit hooks, logging, project structure).

Addresses the PyPI collection mention and notes ambiguity regarding current Redis engine implementation.

## Summary by Sourcery

Revise the README to a clear, consolidated one-page documentation that serves both end users and developers.

Documentation:
- Overhaul README into two parts: a high-level “What/Who/Why” overview with installation instructions and usage examples, and an advanced technical deep dive on internals and contributing guidelines.
- Clarify installation options for basic, all, and individual backends, and emphasize that no standalone CLI exists.
- Provide programmatic examples for all cache decorators (mcache, bcache, fcache, acache, ucache) and for using CacheContext.
- Include a detailed section on architecture: decorators, configuration, cache engines and manager, context management, backend selection, and key generation.
- Add guidelines on coding conventions, style, dependencies, testing, CI, contribution process, pre-commit hooks, logging, and project structure.
- Mention the twat collection on PyPI and clarify the current status of Redis engine support.